### PR TITLE
Hōo主機有30 分鐘，下載docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ jobs:
         - chmod 400 "${TRAVIS_TSUKI_SSH_KEY_PATH}"
       script:
         - >
+          travis_wait 30
           ansible-playbook -i deploy/inventory_travis deploy/deploy.yaml
           --extra-vars "tsuanan_repo=`basename ${TRAVIS_REPO_SLUG}`"
           --extra-vars "branch=${TRAVIS_BRANCH}"


### PR DESCRIPTION
https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

本底Travis CI預設10分鐘會timeout，因為AI模型加起來超過10GB，會直直timeout，所以設定30分鐘，hōo流程較穩定--leh。