### PR TITLE
gradio, mcp版本改做仝款

### DIFF
--- a/asr-kaldi/requirements.in
+++ b/asr-kaldi/requirements.in
@@ -5,10 +5,10 @@ hf-transfer>=0.1.4
 click<8.1
 pydantic
 
-gradio[oauth,mcp]==5.30.0
+gradio[oauth,mcp]==5.32.0
 uvicorn>=0.14.0
 spaces
-mcp==1.11.0
+mcp
 
 vosk
 omegaconf

--- a/asr-kaldi/requirements.in
+++ b/asr-kaldi/requirements.in
@@ -5,7 +5,7 @@ hf-transfer>=0.1.4
 click<8.1
 pydantic
 
-gradio[oauth,mcp]==5.32.0
+gradio[oauth,mcp]==5.37.0
 uvicorn>=0.14.0
 spaces
 mcp

--- a/asr-kaldi/requirements.txt
+++ b/asr-kaldi/requirements.txt
@@ -26,8 +26,13 @@ anyio==4.9.0
 async-timeout==5.0.1
     # via aiohttp
 attrs==25.3.0
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   jsonschema
+    #   referencing
 authlib==1.5.2
+    # via gradio
+brotli==1.1.0
     # via gradio
 certifi==2025.4.26
     # via
@@ -72,11 +77,11 @@ fsspec[http]==2025.3.0
     #   datasets
     #   gradio-client
     #   huggingface-hub
-gradio[mcp,oauth]==5.32.0
+gradio[mcp,oauth]==5.37.0
     # via
     #   -r requirements.in
     #   spaces
-gradio-client==1.10.2
+gradio-client==1.10.4
     # via gradio
 groovy==0.1.2
     # via gradio
@@ -115,13 +120,17 @@ itsdangerous==2.2.0
     # via gradio
 jinja2==3.1.6
     # via gradio
+jsonschema==4.24.0
+    # via mcp
+jsonschema-specifications==2025.4.1
+    # via jsonschema
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.2
     # via
     #   gradio
     #   jinja2
-mcp==1.9.0
+mcp==1.10.1
     # via
     #   -r requirements.in
     #   gradio
@@ -197,6 +206,10 @@ pyyaml==6.0.2
     #   gradio
     #   huggingface-hub
     #   omegaconf
+referencing==0.36.2
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.32.4
     # via
     #   datasets
@@ -205,6 +218,10 @@ requests==2.32.4
     #   vosk
 rich==14.0.0
     # via typer
+rpds-py==0.26.0
+    # via
+    #   jsonschema
+    #   referencing
 ruff==0.11.10
     # via gradio
 safehttpx==0.1.6
@@ -249,6 +266,7 @@ typing-extensions==4.13.2
     #   multidict
     #   pydantic
     #   pydantic-core
+    #   referencing
     #   rich
     #   spaces
     #   typer

--- a/asr-kaldi/requirements.txt
+++ b/asr-kaldi/requirements.txt
@@ -26,10 +26,7 @@ anyio==4.9.0
 async-timeout==5.0.1
     # via aiohttp
 attrs==25.3.0
-    # via
-    #   aiohttp
-    #   jsonschema
-    #   referencing
+    # via aiohttp
 authlib==1.5.2
     # via gradio
 certifi==2025.4.26
@@ -75,11 +72,11 @@ fsspec[http]==2025.3.0
     #   datasets
     #   gradio-client
     #   huggingface-hub
-gradio[mcp,oauth]==5.30.0
+gradio[mcp,oauth]==5.32.0
     # via
     #   -r requirements.in
     #   spaces
-gradio-client==1.10.1
+gradio-client==1.10.2
     # via gradio
 groovy==0.1.2
     # via gradio
@@ -118,17 +115,13 @@ itsdangerous==2.2.0
     # via gradio
 jinja2==3.1.6
     # via gradio
-jsonschema==4.24.0
-    # via mcp
-jsonschema-specifications==2025.4.1
-    # via jsonschema
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.2
     # via
     #   gradio
     #   jinja2
-mcp==1.11.0
+mcp==1.9.0
     # via
     #   -r requirements.in
     #   gradio
@@ -204,10 +197,6 @@ pyyaml==6.0.2
     #   gradio
     #   huggingface-hub
     #   omegaconf
-referencing==0.36.2
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.4
     # via
     #   datasets
@@ -216,10 +205,6 @@ requests==2.32.4
     #   vosk
 rich==14.0.0
     # via typer
-rpds-py==0.26.0
-    # via
-    #   jsonschema
-    #   referencing
 ruff==0.11.10
     # via gradio
 safehttpx==0.1.6
@@ -264,7 +249,6 @@ typing-extensions==4.13.2
     #   multidict
     #   pydantic
     #   pydantic-core
-    #   referencing
     #   rich
     #   spaces
     #   typer

--- a/asr/requirements.in
+++ b/asr/requirements.in
@@ -5,7 +5,7 @@ hf-transfer>=0.1.4
 click<8.1
 pydantic
 
-gradio[oauth,mcp]==5.32.0
+gradio[oauth,mcp]==5.37.0
 uvicorn>=0.14.0
 spaces
 

--- a/asr/requirements.txt
+++ b/asr/requirements.txt
@@ -30,11 +30,16 @@ asteroid-filterbanks==0.4.0
 async-timeout==5.0.1
     # via aiohttp
 attrs==25.3.0
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   jsonschema
+    #   referencing
 authlib==1.6.0
     # via gradio
 av==14.4.0
     # via faster-whisper
+brotli==1.1.0
+    # via gradio
 certifi==2025.6.15
     # via
     #   httpcore
@@ -110,11 +115,11 @@ fsspec[http]==2025.3.0
     #   lightning
     #   pytorch-lightning
     #   torch
-gradio[mcp,oauth]==5.32.0
+gradio[mcp,oauth]==5.37.0
     # via
     #   -r requirements.in
     #   spaces
-gradio-client==1.10.2
+gradio-client==1.10.4
     # via gradio
 greenlet==3.2.3
     # via sqlalchemy
@@ -173,6 +178,10 @@ joblib==1.5.1
     #   nltk
     #   scikit-learn
     #   speechbrain
+jsonschema==4.24.0
+    # via mcp
+jsonschema-specifications==2025.4.1
+    # via jsonschema
 julius==0.2.7
     # via torch-audiomentations
 kiwisolver==1.4.8
@@ -195,7 +204,7 @@ markupsafe==3.0.2
     #   mako
 matplotlib==3.10.3
     # via pyannote-metrics
-mcp==1.9.0
+mcp==1.10.1
     # via gradio
 mdurl==0.1.2
     # via markdown-it-py
@@ -390,6 +399,10 @@ pyyaml==6.0.2
     #   pyannote-pipeline
     #   pytorch-lightning
     #   transformers
+referencing==0.36.2
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 regex==2024.11.6
     # via
     #   nltk
@@ -404,6 +417,10 @@ rich==14.0.0
     # via
     #   pyannote-audio
     #   typer
+rpds-py==0.26.0
+    # via
+    #   jsonschema
+    #   referencing
 ruamel-yaml==0.18.14
     # via hyperpyyaml
 ruamel-yaml-clib==0.2.12
@@ -543,6 +560,7 @@ typing-extensions==4.14.0
     #   pydantic
     #   pydantic-core
     #   pytorch-lightning
+    #   referencing
     #   rich
     #   spaces
     #   sqlalchemy

--- a/tts/requirements.in
+++ b/tts/requirements.in
@@ -6,7 +6,7 @@ click<8.1
 pydantic
 torch
 
-gradio[oauth]==5.9.1
+gradio[oauth]==5.32.0
 uvicorn>=0.14.0
 spaces==0.36.0
 

--- a/tts/requirements.in
+++ b/tts/requirements.in
@@ -6,7 +6,7 @@ click<8.1
 pydantic
 torch
 
-gradio[oauth]==5.32.0
+gradio[oauth]==5.37.0
 uvicorn>=0.14.0
 spaces==0.36.0
 

--- a/tts/requirements.txt
+++ b/tts/requirements.txt
@@ -43,6 +43,8 @@ botocore==1.38.18
     # via
     #   boto3
     #   s3transfer
+brotli==1.1.0
+    # via gradio
 cached-path==1.7.3
     # via f5-tts
 cachetools==5.5.2
@@ -149,12 +151,12 @@ google-resumable-media==2.7.2
     # via google-cloud-storage
 googleapis-common-protos==1.70.0
     # via google-api-core
-gradio[oauth]==5.32.0
+gradio[oauth]==5.37.0
     # via
     #   -r requirements.in
     #   f5-tts
     #   spaces
-gradio-client==1.10.2
+gradio-client==1.10.4
     # via gradio
 groovy==0.1.2
     # via gradio

--- a/tts/requirements.txt
+++ b/tts/requirements.txt
@@ -149,12 +149,14 @@ google-resumable-media==2.7.2
     # via google-cloud-storage
 googleapis-common-protos==1.70.0
     # via google-api-core
-gradio[oauth]==5.9.1
+gradio[oauth]==5.32.0
     # via
     #   -r requirements.in
     #   f5-tts
     #   spaces
-gradio-client==1.5.2
+gradio-client==1.10.2
+    # via gradio
+groovy==0.1.2
     # via gradio
 h11==0.16.0
     # via


### PR DESCRIPTION
因為資安警告，`gradio`攏統一改做`5.32.0`，`m̀cp`攏統一改做`1.10.1`

gradio:

1. https://github.com/i3thuan5/Formosan-AI/security/dependabot/14
2. https://github.com/i3thuan5/Formosan-AI/security/dependabot/19
3. https://github.com/i3thuan5/Formosan-AI/security/dependabot/22
3. https://github.com/i3thuan5/Formosan-AI/security/dependabot/63
3. https://github.com/i3thuan5/Formosan-AI/security/dependabot/66

mcp:

1. https://github.com/i3thuan5/Formosan-AI/security/dependabot/83
2. https://github.com/i3thuan5/Formosan-AI/security/dependabot/85

警告例：
<img width="1687" height="922" alt="image" src="https://github.com/user-attachments/assets/20224464-fa00-433a-8906-7eb770757f0a" />
