### PR TITLE
更新multidict

### DIFF
--- a/asr-kaldi/requirements.txt
+++ b/asr-kaldi/requirements.txt
@@ -136,7 +136,7 @@ mcp==1.10.1
     #   gradio
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.4.4
+multidict==6.6.3
     # via
     #   aiohttp
     #   yarl

--- a/asr/requirements.txt
+++ b/asr/requirements.txt
@@ -210,7 +210,7 @@ mdurl==0.1.2
     # via markdown-it-py
 mpmath==1.3.0
     # via sympy
-multidict==6.5.0
+multidict==6.6.3
     # via
     #   aiohttp
     #   yarl

--- a/tts/requirements.txt
+++ b/tts/requirements.txt
@@ -235,7 +235,7 @@ mpmath==1.3.0
     # via sympy
 msgpack==1.1.0
     # via librosa
-multidict==6.4.3
+multidict==6.6.3
     # via
     #   aiohttp
     #   yarl


### PR DESCRIPTION
pip-compile警告
```
  WARNING: The candidate selected for download or install is a yanked version: 'multidict' candidate (version 6.5.0 at https://files.pythonhosted.org/packages/bf/5e/f7e0fd5f5b8a7b9a75b0f5642ca6b6dde90116266920d8cf63b513f3908b/multidict-6.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (from https://pypi.org/simple/multidict/) (requires-python:>=3.9))
  Reason for being yanked: The version has a regression in 'md.update()' in certain conditions
```
https://pypi.org/project/multidict/#history
<img width="1833" height="1002" alt="圖片" src="https://github.com/user-attachments/assets/45ae6e57-35a9-4155-b0b8-94137183a075" />
